### PR TITLE
Fix asset paths for cargo-built executables

### DIFF
--- a/image/src/main.rs
+++ b/image/src/main.rs
@@ -36,7 +36,7 @@ impl App {
 
 impl Game for App {
     fn load(&mut self) {
-        let asset_store = AssetStore::from_folder("assets");
+        let asset_store = AssetStore::from_folder("../bin/assets");
         let image = asset_store.path("rust-logo.png").unwrap();
         self.image = Some(Texture::from_path(&image).unwrap());
     }

--- a/image_iter/src/main.rs
+++ b/image_iter/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
         }
     );
 
-    let asset_store = AssetStore::from_folder("assets");
+    let asset_store = AssetStore::from_folder("../bin/assets");
 
     let image = asset_store.path("rust-logo.png").unwrap();
     let image = Texture::from_path(&image).unwrap();


### PR DESCRIPTION
Building the example executables with cargo, the binaries are placed in a "target" folder, not "bin". Thus, the assets can not be found by such executables. Pointing the AssetStore to "../bin/assets" fixes this.
