### PR TITLE
removed crate that is no longer in cargo package. Not needed to compile

### DIFF
--- a/image/src/main.rs
+++ b/image/src/main.rs
@@ -5,7 +5,6 @@ extern crate event;
 extern crate graphics;
 extern crate sdl2_window;
 extern crate opengl_graphics;
-extern crate input;
 
 use std::cell::RefCell;
 use opengl_graphics::{


### PR DESCRIPTION
input crate was being referred to, causing compiler errors. So i fixed :)