### PR TITLE
Switched dependency from `cam` to `camera_controllers`

### DIFF
--- a/gfx_cube/Cargo.toml
+++ b/gfx_cube/Cargo.toml
@@ -14,8 +14,8 @@ git = "https://github.com/PistonDevelopers/piston"
 [dependencies.pistoncore-sdl2_window]
 git = "https://github.com/pistondevelopers/sdl2_window"
 
-[dependencies.piston3d-cam]
-git = "https://github.com/PistonDevelopers/cam"
+[dependencies.camera_controllers]
+git = "https://github.com/PistonDevelopers/camera_controllers"
 
 [dependencies.shader_version]
 git = "https://github.com/PistonDevelopers/shader_version"

--- a/gfx_cube/src/main.rs
+++ b/gfx_cube/src/main.rs
@@ -4,7 +4,7 @@
 extern crate piston;
 extern crate shader_version;
 extern crate vecmath;
-extern crate cam;
+extern crate camera_controllers;
 extern crate gfx;
 extern crate gfx_device_gl;
 extern crate sdl2;
@@ -16,7 +16,7 @@ use piston::quack::Set;
 use piston::window::{ WindowSettings, CaptureCursor };
 use piston::event::RenderEvent;
 use shader_version::OpenGL;
-use cam::{
+use camera_controllers::{
     FirstPersonSettings,
     FirstPerson,
     CameraPerspective,


### PR DESCRIPTION
FirstPerson is going to be removed in PistonDevelopers/cam#50