### PR TITLE
Workaround rustc ICE: `debuginfo: Could not find scope info for node Nod...

### DIFF
--- a/user_input/Cargo.toml
+++ b/user_input/Cargo.toml
@@ -37,3 +37,8 @@ default = ["include_glfw"]
 include_sdl2 = ["pistoncore-sdl2_window"]
 include_glfw = ["pistoncore-glfw_window"]
 include_glutin = ["pistoncore-glutin_window"]
+
+### Workaround rustc ICE ###
+[profile.dev]
+debug = false
+############################


### PR DESCRIPTION
...eExpr(...)`