### PR TITLE
Change hyphens in target names to underscores

### DIFF
--- a/deform/Cargo.toml
+++ b/deform/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = []
 
 [[bin]]
-name = "piston-examples-deform"
+name = "piston_examples_deform"
 path = "src/main.rs"
 
 [dependencies.piston]

--- a/gfx_cube/Cargo.toml
+++ b/gfx_cube/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Your Name <your@email.com>"]
 keywords = []
 
 [[bin]]
-name = "piston-example-gfx_cube"
+name = "piston_example_gfx_cube"
 path = "src/main.rs"
 
 [dependencies.piston]

--- a/image/Cargo.toml
+++ b/image/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Your Name <your@email.com>"]
 keywords = []
 
 [[bin]]
-name = "piston-example-image"
+name = "piston_example_image"
 path = "src/main.rs"
 
 [dependencies.piston]

--- a/sprite/Cargo.toml
+++ b/sprite/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Coeuvre Wong <coeuvre@gmail.com>"]
 keywords = []
 
 [[bin]]
-name = "piston-example-sprite"
+name = "piston_example_sprite"
 path = "src/main.rs"
 
 [dependencies.pistoncore-sdl2_window]

--- a/user_input/Cargo.toml
+++ b/user_input/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Your Name <your@email.com>"]
 keywords = []
 
 [[bin]]
-name = "piston-example-user_input"
+name = "piston_example_user_input"
 path = "src/main.rs"
 
 [dependencies.piston]


### PR DESCRIPTION
Because Cargo now errors when explicitely named targets contain hyphens:
https://github.com/rust-lang/cargo/pull/1443

I ran into this trying to build these examples just now.