### PR TITLE
Remove a useless call to mouse_cursor_args() while handling a MouseButton event

### DIFF
--- a/src/paint.rs
+++ b/src/paint.rs
@@ -23,7 +23,7 @@ fn main() {
             &TextureSettings::new()
         ).unwrap();
 
-    let mut last_pos = None;
+    let mut last_pos: Option<[f64; 2]> = None;
 
     while let Some(e) = window.next() {
         if let Event::Render(_) = e {
@@ -36,7 +36,6 @@ fn main() {
         if let Some(button) = e.press_args() {
             if button == Button::Mouse(MouseButton::Left) {
                 draw = true;
-                last_pos = e.mouse_cursor_args()
             }
         };
         if let Some(button) = e.release_args() {


### PR DESCRIPTION
Addresses #375.

This function only returns None when a MouseButton event is being triggered, so there's no point in calling it and saving its value. The code later in the function which calls it again is all that's necessary.

I also had to explicitly annotate the type of `last_pos` because it seems the Rust type inference engine can't figure out what its type should be without an explicit assignment to the result of the function.