### PR TITLE
Make sdl2 dependency optional in the freetype example

### DIFF
--- a/freetype/Cargo.toml
+++ b/freetype/Cargo.toml
@@ -12,6 +12,23 @@ path = "src/main.rs"
 piston = "0.50.0"
 piston2d-opengl_graphics = "0.72.0"
 piston2d-graphics = "0.36.0"
-pistoncore-sdl2_window = "0.64.0"
 freetype-rs = "0.26.0"
 find_folder = "0.3.0"
+
+[dependencies.pistoncore-sdl2_window]
+version = "0.64.0"
+optional = true
+
+[dependencies.pistoncore-glfw_window]
+version = "0.66.0"
+optional = true
+
+[dependencies.pistoncore-glutin_window]
+version = "0.64.0"
+optional = true
+
+[features]
+default = ["include_glfw"]
+include_sdl2 = ["pistoncore-sdl2_window"]
+include_glfw = ["pistoncore-glfw_window"]
+include_glutin = ["pistoncore-glutin_window"]

--- a/freetype/src/main.rs
+++ b/freetype/src/main.rs
@@ -1,11 +1,23 @@
 extern crate graphics;
 extern crate freetype as ft;
-extern crate sdl2_window;
 extern crate opengl_graphics;
 extern crate piston;
 extern crate find_folder;
 
-use sdl2_window::Sdl2Window;
+#[cfg(feature = "include_sdl2")]
+extern crate sdl2_window;
+#[cfg(feature = "include_glfw")]
+extern crate glfw_window;
+#[cfg(feature = "include_glutin")]
+extern crate glutin_window;
+
+#[cfg(feature = "include_sdl2")]
+use sdl2_window::Sdl2Window as AppWindow;
+#[cfg(feature = "include_glfw")]
+use glfw_window::GlfwWindow as AppWindow;
+#[cfg(feature = "include_glutin")]
+use glutin_window::GlutinWindow as AppWindow;
+
 use opengl_graphics::{ GlGraphics, Texture, TextureSettings, OpenGL };
 use piston::window::WindowSettings;
 use piston::input::*;
@@ -52,7 +64,7 @@ fn render_text<G, T>(glyphs: &[(T, [f64; 2])], c: &Context, gl: &mut G)
 
 fn main() {
     let opengl = OpenGL::V3_2;
-    let mut window: Sdl2Window =
+    let mut window: AppWindow =
         WindowSettings::new("piston-example-freetype", [300, 300])
         .exit_on_esc(true)
         .graphics_api(opengl)


### PR DESCRIPTION
The user_input example avoids requiring SDL2 to be installed by using optional dependencies and cfg, this PR adapts the same approach in the freetype example so that the example can be built and ran on windows without multiple additional dependencies that the other examples do not require.